### PR TITLE
feat(proto): update workflow definition types

### DIFF
--- a/proto/sapphillon/v1/workflow_service.proto
+++ b/proto/sapphillon/v1/workflow_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package sapphillon.v1;
 
 import "google/rpc/status.proto";
+import "sapphillon/v1/workflow.proto";
 
 // Generates and fixes structured workflow definitions from natural language descriptions.
 // Methods stream partial outputs to allow progressive rendering in UIs and long-running processing.
@@ -60,10 +61,7 @@ message GenerateWorkflowRequest {
 // Each streamed message may be partial; the client should merge or replace as appropriate.
 message GenerateWorkflowResponse {
   // Structured workflow definition.
-  // Format: String-encoded structure such as JSON or YAML.
-  // Example (JSON):
-  //   {"steps":[{"id":"check_weather"},{"id":"notify","if":"raining"}]}
-  string workflow_definition = 1;
+  sapphillon.v1.Workflow workflow_definition = 1;
 
   // The status of the response.
   // If the status is not OK, it indicates an error.
@@ -87,8 +85,7 @@ message FixWorkflowRequest {
 // The final message typically represents the complete fixed definition.
 message FixWorkflowResponse {
   // The fixed workflow definition.
-  // Format: JSON, YAML, or another structured text representation.
-  string fixed_workflow_definition = 1;
+  sapphillon.v1.Workflow fixed_workflow_definition = 1;
 
   // Summary of changes applied to produce the fixed definition.
   // Example: "Renamed duplicate step IDs; added retry policy to 'notify'."


### PR DESCRIPTION
This pull request updates the workflow service API to use a strongly-typed `Workflow` message instead of raw string representations for workflow definitions. This change improves type safety and clarity in the API.

**API improvements:**

* The `GenerateWorkflowResponse` and `FixWorkflowResponse` messages now use the `sapphillon.v1.Workflow` message type for the `workflow_definition` and `fixed_workflow_definition` fields, replacing the previous string-encoded formats. [[1]](diffhunk://#diff-cae4eee5cea973bda5cd9d95b2c78c0f81d3aff0f40a8097a4d307cd91d524abL63-R64) [[2]](diffhunk://#diff-cae4eee5cea973bda5cd9d95b2c78c0f81d3aff0f40a8097a4d307cd91d524abL90-R88)
* Added an import for `sapphillon/v1/workflow.proto` to provide the `Workflow` message definition